### PR TITLE
Issue#6: Support correct pact specification version format

### DIFF
--- a/PactNetMessages.Tests/Models/PactFileTests.cs
+++ b/PactNetMessages.Tests/Models/PactFileTests.cs
@@ -11,7 +11,7 @@ namespace PactNetMessages.Tests.Models
         public void Ctor_WhenInstantiated_SetsPactSpecificationVersionMetaDataTo3()
         {
             var pactFile = new PactFile();
-            var expected = new {pactSpecificationVersion = "3.0"};
+            var expected = new { pactSpecification = new { version = "3.0.0" }, pactSpecificationVersion = "3.0" };
 
             Assert.Equal(JsonConvert.SerializeObject(expected), JsonConvert.SerializeObject(pactFile.Metadata));
         }

--- a/PactNetMessages/Models/PactFile.cs
+++ b/PactNetMessages/Models/PactFile.cs
@@ -12,6 +12,10 @@ namespace PactNetMessages.Models
         {
             Metadata = new
             {
+                pactSpecification = new
+                {
+                    version = "3.0.0"
+                },
                 pactSpecificationVersion = "3.0"
             };
         }


### PR DESCRIPTION
Added support for the pactSpecification.version pact file format specification to be compatible with other PactProvider libraries.
This solves issue https://github.com/Mattersight/pact-net-messages/issues/6